### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <drools.bundle.version>5.5.0.Final_2</drools.bundle.version>
         <quartz.bundle.version>1.8.6_1</quartz.bundle.version>
         <mvel.bundle.version>2.1.3.Final</mvel.bundle.version>
-        <commons-collections-version>3.2.1</commons-collections-version>
+        <commons-collections-version>3.2.2</commons-collections-version>
         <asm.bundle.version>3.3.1_1</asm.bundle.version>
         <antlr2.bundle.version>2.7.7_5</antlr2.bundle.version>
         <rhino.bundle.version>1.7R2_3</rhino.bundle.version>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That is the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
